### PR TITLE
Remove mutex by pre-allocating the slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.17.4
+VERSION=1.17.5
 PATH_BUILD=build/
 FILE_COMMAND=terragrunt-atlantis-config
 FILE_ARCH=darwin_amd64

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"regexp"
+	"slices"
 	"sort"
 
 	"github.com/hashicorp/go-getter"
@@ -699,15 +700,21 @@ func main(cmd *cobra.Command, args []string) error {
 	errGroup, _ := errgroup.WithContext(ctx)
 	sem := semaphore.NewWeighted(numExecutors)
 
+	projects := make(map[string][]AtlantisProject, len(workingDirs))
+
 	for _, workingDir := range workingDirs {
 		terragruntFiles, err := getAllTerragruntFiles(workingDir)
+
 		if err != nil {
 			return err
 		}
 
+		projects[workingDir] = make([]AtlantisProject, len(terragruntFiles))
+
 		if len(projectHclDirs) == 0 || createHclProjectChilds || (createHclProjectExternalChilds && workingDir == gitRoot) {
 			// Concurrently looking all dependencies
-			for _, terragruntPath := range terragruntFiles {
+			for i, terragruntPath := range terragruntFiles {
+				idx := i
 				terragruntPath := terragruntPath // https://golang.org/doc/faq#closures_and_goroutines
 
 				// don't create atlantis projects already covered by project hcl file projects
@@ -739,10 +746,6 @@ func main(cmd *cobra.Command, args []string) error {
 						return nil
 					}
 
-					// Lock the list as only one goroutine should be writing to config.Projects at a time
-					lock.Lock()
-					defer lock.Unlock()
-
 					// When preserving existing projects, we should update existing blocks instead of creating a
 					// duplicate, when generating something which already has representation
 					if preserveProjects {
@@ -767,7 +770,7 @@ func main(cmd *cobra.Command, args []string) error {
 						}
 					} else {
 						log.Info("Created project for ", terragruntPath)
-						config.Projects = append(config.Projects, *project)
+						projects[workingDir][idx] = *project
 					}
 
 					return nil
@@ -810,7 +813,11 @@ func main(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-
+	for _, v := range projects {
+		config.Projects = append(config.Projects, v...)
+	}
+	// Since we pre-allocate the Projects slice we may have projects with empty dirs (default). Remove them.
+	config.Projects = slices.DeleteFunc(config.Projects, func(prj AtlantisProject) bool { return prj.Dir == "" })
 	// Sort the projects in config by Dir
 	sort.Slice(config.Projects, func(i, j int) bool { return config.Projects[i].Dir < config.Projects[j].Dir })
 


### PR DESCRIPTION
This PR removes the mutex around the projects slice by pre-allocating the underlying slice with size the total number of Terragrunt files, since it's not possible to have more projects than Terragrunt files. 